### PR TITLE
bump avax testnet to v.1.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG AVALANCHE_REPO="https://github.com/ava-labs/avalanchego.git"
-ARG AVALANCHE_RELEASE="v1.8.5"
+ARG AVALANCHE_RELEASE="v1.9.0-fuji"
 
 ARG AVALANCHE_SUBNETS_REPO="https://github.com/ava-labs/subnet-evm"
 ARG AVALANCHE_SUBNETS_RELEASE="v0.3.0"


### PR DESCRIPTION
- bump avax testnet to v.1.9.0 (https://chainstackhq.slack.com/archives/C02V5K2G2JZ/p1664463511443329)
- test upgrade using it