### PR TITLE
bump avax version to 1.9.1 and evmsubnet to 0.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG AVALANCHE_REPO="https://github.com/ava-labs/avalanchego.git"
-ARG AVALANCHE_RELEASE="v1.9.0-fuji-post-upgrade"
+ARG AVALANCHE_RELEASE="v1.9.1"
 
 ARG AVALANCHE_SUBNETS_REPO="https://github.com/ava-labs/subnet-evm"
-ARG AVALANCHE_SUBNETS_RELEASE="v0.3.0"
+ARG AVALANCHE_SUBNETS_RELEASE="v0.4.2"
 
 ARG DFK_ETH_CHAIN_ID="53935"
 ARG DFK_VM_ID="mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv"


### PR DESCRIPTION
bump avax fuji version to 1.9.1 and evmsubnet to 0.4.2

context : https://chainstackhq.slack.com/archives/C02RNV8J3UM/p1667521210034069