### PR TITLE
Upgrade image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG AVALANCHE_REPO="https://github.com/ava-labs/avalanchego.git"
-ARG AVALANCHE_RELEASE="v1.9.8"
+ARG AVALANCHE_RELEASE="v1.9.11"
 
 ARG AVALANCHE_SUBNETS_REPO="https://github.com/ava-labs/subnet-evm"
-ARG AVALANCHE_SUBNETS_RELEASE="v0.4.8"
+ARG AVALANCHE_SUBNETS_RELEASE="v0.4.12"
 
 ARG AVALANCHE_SUBNETS_NETWORKS_REPO="https://github.com/ava-labs/public-chain-assets"
 ARG AVALANCHE_SUBNETS_NETWORKS_RELEASE="main"


### PR DESCRIPTION
Upgrading https://github.com/ava-labs/avalanchego.git and https://github.com/ava-labs/subnet-evm image version.

Related ticket - https://chainstack.myjetbrains.com/youtrack/agiles/121-11/current?query=assignee:%20felipe.estrella%20&issue=OPS-1691